### PR TITLE
feat: Add preview of files to be deleted before confirmation when pruning

### DIFF
--- a/src/actions/prune.test.ts
+++ b/src/actions/prune.test.ts
@@ -53,6 +53,24 @@ describe('The prune action', () => {
     expect(logMessage).toMatchInlineSnapshot('"You have no files in your mods folder."');
   });
 
+  it<LocalTestContext>('notifies about the files to be deleted in the mods folder', async ({ options, logger }) => {
+    const file1 = "a.jar";
+    const file2 = "b.jar";
+
+    const expectedFile1 = path.resolve(configuration.modsFolder, file1);
+    const expectedFile2 = path.resolve(configuration.modsFolder, file2);
+
+    vi.mocked(getModFiles).mockResolvedValueOnce([file1, file2]);
+
+    await prune(options, logger);
+
+    const logMessages = vi.mocked(logger.log).mock.calls.map((l) => { return l[0] });
+
+    expect(logMessages[0]).toMatchInlineSnapshot('"The following files are unmanaged:"');
+    expect(logMessages[1]).toMatchInlineSnapshot('- ${expectedFile1}');
+    expect(logMessages[2]).toMatchInlineSnapshot('- ${expectedFile2}');
+  });
+
   it<LocalTestContext>('notifies about no unmanaged files in the mods folder', async ({ options, logger }) => {
     vi.mocked(getModFiles).mockResolvedValueOnce(chance.n(chance.word, chance.integer({ min: 2, max: 10 })));
     vi.mocked(fileIsManaged).mockReturnValue(true);

--- a/src/actions/prune.ts
+++ b/src/actions/prune.ts
@@ -30,6 +30,11 @@ export const prune = async (options: PruneOptions, logger: Logger) => {
   if (unmanaged.length === 0) {
     logger.log('You have no unmanaged mods in your mods folder.');
     return;
+  } else {
+    logger.log('The following files are unmanaged:');
+    for (const file of unmanaged) {
+      logger.log('- ${filePath}');
+    }
   }
 
   if (!await shouldPruneFiles(options, logger)) {


### PR DESCRIPTION
I've had to prune a couple of times and it's always a bit anxiety-inducing to give it that final OK because you're not _quite_ sure what it's going to delete

This PR adds a preview before you confirm so you can review and give the go-ahead in full confidence.