### PR TITLE
Add API integration docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Guidance
+
+- Refer to `docs/requirements-go-port.md` for an overview of the current Node implementation and expectations for the Go port.
+- See `docs/commands/README.md` for detailed behaviour of each CLI command.
+- Review `docs/platform-apis.md` for specifics on interacting with CurseForge and Modrinth.
+- Keep documentation in sync with features.

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -1,0 +1,24 @@
+# Command Reference
+
+This section documents how each CLI command operates. These guides are intended for the Go port and describe the logic without referring to implementation details of the original TypeScript code.
+
+- [init](init.md)
+- [add](add.md)
+- [install](install.md)
+- [update](update.md)
+- [list](list.md)
+- [change](change.md)
+- [test](test.md)
+- [prune](prune.md)
+- [scan](scan.md)
+- [remove](remove.md)
+
+## Global Options
+
+Every command supports a few shared flags provided by the CLI parser:
+
+- `-c, --config <file>` – path to `modlist.json`. Defaults to `./modlist.json`.
+- `-q, --quiet` – suppresses prompts and normal log output.
+- `-d, --debug` – prints additional debug messages.
+
+These options must appear before the command name, e.g. `mmm --quiet install`.

--- a/docs/commands/add.md
+++ b/docs/commands/add.md
@@ -1,0 +1,18 @@
+# `add`
+
+Adds a mod to the configuration and downloads the corresponding file.
+
+## Behaviour
+1. Ensure `modlist.json` and `modlist-lock.json` exist, creating them when needed.
+2. Fetch metadata for the given `<platform>` and `<id>` using the configured loader and Minecraft version. When `--version` is supplied, that specific version is requested. The optional `--allow-version-fallback` flag allows searching previous Minecraft versions when no file matches the current one.
+3. Download the discovered file into the mods directory.
+4. Append a mod entry to `modlist.json` and an installation record to `modlist-lock.json`.
+
+## Edge Cases
+- Unknown platform prompts the user to pick a valid platform.
+- If the project ID cannot be found, the user is asked to modify the search or abort.
+- When no compatible file exists for the selected platform, the user is offered the choice to try the alternate platform and enter a different ID.
+- Download failures terminate the command with an error.
+
+## User Interaction
+Depending on flags and failures, the command may prompt the user to adjust the platform or project ID, or to confirm retrying on a different platform. Quiet mode skips prompts and fails immediately on errors.

--- a/docs/commands/change.md
+++ b/docs/commands/change.md
@@ -1,0 +1,15 @@
+# `change`
+
+Switches the configured Minecraft version and reinstalls all mods for the new version.
+
+## Behaviour
+1. Verify that the target version is supported by all configured mods (unless `--force` is used). This mirrors the behaviour of the `test` command.
+2. Remove all currently installed mod files and update `modlist.json` with the new `gameVersion` value.
+3. Run `install` to download compatible versions for the new game version.
+
+## Edge Cases
+- Attempting to change to the existing game version exits with code `2`.
+- When mods are missing support for the new version, the command fails with code `1` unless `--force` is provided.
+
+## User Interaction
+Any errors are logged to the console. With `--force` the version is changed even if some mods fail to install; missing mods are simply skipped.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -1,0 +1,17 @@
+# `init`
+
+Initialises `modlist.json` and prepares the working directory. The command can operate interactively or receive all answers via flags.
+
+## Behaviour
+1. Determine the configuration file location. If it already exists and the `--quiet` flag is not used, the user is asked whether to overwrite or provide a new file name.
+2. Gather required values (loader, Minecraft version, allowed release types and mods directory) through command line options or interactive prompts.
+3. Validate that the chosen mods directory exists and that the supplied Minecraft version is valid. If the game version is omitted, the tool retrieves the latest release from the official API and falls back to a prompt when the API is unavailable.
+4. Write the resulting configuration to disk and create an empty `modlist-lock.json`.
+
+## Edge Cases
+- Invalid or nonexistent mods folder results in a prompt for a different path.
+- Invalid Minecraft versions throw an error and the process aborts.
+- When running in `--quiet` mode and the config file already exists, the command exits with an error.
+
+## User Interaction
+The user may be prompted to confirm overwriting files, choose values from lists or provide text input. All prompts are skipped when the relevant flags are supplied.

--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -1,0 +1,19 @@
+# `install`
+
+Downloads all mods listed in `modlist.json` according to the lock file.
+
+## Behaviour
+1. Load the configuration and existing `modlist-lock.json` records.
+2. Scan the mods directory for unmanaged files; unresolved matches produce an error suggesting a manual `scan` run.
+3. For each configured mod:
+   - If a matching installation exists, verify the local file's hash and redownload when it differs or is missing.
+   - If no installation exists, fetch remote metadata and download the file.
+4. Update `modlist-lock.json` and persist any new names in `modlist.json`.
+
+## Edge Cases
+- Hash mismatches trigger re-downloads to ensure integrity.
+- Unmanaged files halt the process until the user resolves them with the `scan` command.
+- Network or download failures surface as errors.
+
+## User Interaction
+The command is mostly non‑interactive, but error messages describe unresolved files and how to address them.

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -1,0 +1,14 @@
+# `list`
+
+Displays the mods defined in `modlist.json` and shows whether each one is currently installed.
+
+## Behaviour
+1. Load the configuration and lock file.
+2. Sort entries alphabetically and print a checkmark for installed mods or a cross for missing files.
+3. The command reports the total number of mods via telemetry.
+
+## Edge Cases
+- If configuration files are missing or invalid, an error is raised.
+
+## User Interaction
+Purely informational. No prompts are issued.

--- a/docs/commands/prune.md
+++ b/docs/commands/prune.md
@@ -1,0 +1,16 @@
+# `prune`
+
+Deletes unmanaged files from the mods directory.
+
+## Behaviour
+1. Load the configuration and lock file to determine which files are managed.
+2. Scan the mods directory and list all files that are not present in `modlist-lock.json`, applying `.mmmignore` rules.
+3. Unless `--force` is specified, ask for confirmation before deleting the files.
+4. Remove the selected files.
+
+## Edge Cases
+- When run in `--quiet` mode without `--force`, the command prints a warning and aborts.
+- If no unmanaged files are found, a message is printed and no further action is taken.
+
+## User Interaction
+Prompts for confirmation unless the `--force` flag is used. The command outputs which files were deleted.

--- a/docs/commands/remove.md
+++ b/docs/commands/remove.md
@@ -1,0 +1,16 @@
+# `remove`
+
+Deletes one or more mods from both the configuration and the filesystem.
+
+## Behaviour
+1. Resolve the provided names or IDs against `modlist.json`, supporting glob patterns for partial matches.
+2. When a matching installation exists, delete the file from the mods directory and remove the entry from `modlist-lock.json`.
+3. Remove the corresponding mod entry from `modlist.json` and save the updated configuration.
+4. When `--dry-run` is used, actions are logged but no files are changed.
+
+## Edge Cases
+- Mods that do not match any pattern are ignored.
+- Missing files are skipped without failing the entire command.
+
+## User Interaction
+The command prints the name of each mod removed. With `--dry-run` it reports what would be removed without performing any deletions.

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -1,0 +1,16 @@
+# `scan`
+
+Searches the mods directory for jar files that are not present in the configuration.
+
+## Behaviour
+1. Enumerate files in the mods directory, ignoring entries that end with `.disabled` and respecting patterns from `.mmmignore`.
+2. For each file found, query the preferred platform (default `modrinth`) to identify the matching project.
+3. Present the results, grouping recognised files and unknown ones.
+4. When executed with `--add`, update `modlist.json` and `modlist-lock.json` to include the discovered mods.
+
+## Edge Cases
+- If the platform lookup fails for a file, it is reported as unsure and no changes are made.
+- Files already managed in the lock file are skipped.
+
+## User Interaction
+Without `--add` and when not running in quiet mode, the user is asked whether to update the configuration after reviewing the results.

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -1,0 +1,17 @@
+# `test`
+
+Checks if all configured mods have versions available for a target Minecraft release.
+
+## Behaviour
+1. Determine the version to test (argument or `latest`). If `latest` is used, the command queries the official API for the newest release.
+2. For each mod in `modlist.json`, fetch metadata for the target version and loader.
+3. If every mod has a valid file, the command prints a success message and exits with code `0`.
+4. If any mod lacks support, the missing mods are listed and the command exits with code `1`.
+5. Supplying the version currently in use results in exit code `2`.
+
+## Edge Cases
+- Invalid or unknown Minecraft versions cause an error message.
+- Network failures retrieving version information prompt the user for the latest version when running interactively.
+
+## User Interaction
+Errors and missing mods are printed to the console. No further interaction is required.

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -1,0 +1,17 @@
+# `update`
+
+Checks for newer releases of each configured mod and downloads them when available.
+
+## Behaviour
+1. Start with an `install` run to ensure the working directory is consistent.
+2. For every mod entry, query the remote platform for a newer file matching the configured Minecraft version and loader.
+3. When a new release is found, download it, remove the previous file and update the lock file entry.
+4. The configuration file is updated to keep mod names in sync.
+
+## Edge Cases
+- If a download fails, the previous version remains on disk and the lock file is not altered.
+- When a mod is pinned to a specific `version`, it is skipped during updates.
+- The command aborts if unmanaged files are detected by the initial `install` phase.
+
+## User Interaction
+The command does not ask for input. Progress and potential errors are reported through log output.

--- a/docs/platform-apis.md
+++ b/docs/platform-apis.md
@@ -1,0 +1,55 @@
+# Platform API Integration
+
+This guide describes how the current TypeScript implementation communicates with the CurseForge and Modrinth services. The Go port should reproduce these behaviours.
+
+## Repository Abstraction
+
+Every platform implements a `Repository` interface with two operations:
+
+- `fetchMod(projectId, allowedReleaseTypes, gameVersion, loader, allowFallback, version?)` – returns `RemoteModDetails` for a single mod file.
+- `lookup(fingerprints)` – resolves SHA‑1 file hashes to potential projects.
+
+Both `Curseforge` and `Modrinth` classes live under `src/repositories/` and use a rate‑limited fetch helper to avoid overwhelming remote APIs. Authentication keys come from the environment (`CURSEFORGE_API_KEY` and `MODRINTH_API_KEY`).
+
+## CurseForge
+
+All requests include an `x-api-key` header. When the API responds with `X-Ratelimit-Remaining` below ten requests, the rate limiter delays further calls based on `X-Ratelimit-Reset`.
+
+### Fetching a Mod
+
+1. **Project metadata** – `GET https://api.curseforge.com/v1/mods/{projectId}` returns the mod name.
+2. **File list** – `GET https://api.curseforge.com/v1/mods/{projectId}/files?gameVersion={gameVersion}&modLoaderType={loader}` lists available files.
+3. Filter files by `sortableGameVersions`, release type and status (`fileStatus` 4 or 10). The latest suitable file is chosen.
+4. If a fixed version is provided the file name must match exactly. When no file matches and `allowFallback` is set, retry using the next lower Minecraft version via `fallbackVersion.ts`.
+5. The resulting file must contain a download URL and a SHA‑1 hash. Absence of either causes an error (`NoRemoteFileFound` or `CurseforgeDownloadUrlError`).
+
+### Lookup by Fingerprint
+
+`POST https://api.curseforge.com/v1/fingerprints` with `{ fingerprints: [sha1, ...] }` returns all matching files. Each entry becomes a `PlatformLookupResult` with the project ID and file details derived from `hashes` and `downloadUrl`.
+
+## Modrinth
+
+Requests send a custom `User-Agent` (`github_com/meza/minecraft-mod-manager/{version}`) and an `Authorization` header containing the API key.
+
+### Fetching a Mod
+
+1. **Project name** – `GET https://api.modrinth.com/v2/project/{projectId}` retrieves the display name.
+2. **Version list** – `GET https://api.modrinth.com/v2/project/{projectId}/version?game_versions=["{gameVersion}"]&loaders=["{loader}"]` fetches available versions.
+3. Candidate versions must match the loader, release type and game version. They are sorted by `date_published` with newest first.
+4. A fixed version bypasses filtering and simply selects the matching `version_number`.
+5. If no suitable version exists and `allowFallback` is true, retry with the next lower Minecraft version.
+6. The selected version's first file provides the download URL and SHA‑1 hash which become the `RemoteModDetails`.
+
+### Lookup by Hash
+
+Each hash triggers
+`GET https://api.modrinth.com/v2/version_file/{hash}?algorithm=sha1`. Successful responses contain the mod version with file metadata; failures are ignored. All successful results are collected into `PlatformLookupResult` objects.
+
+## Rate-Limited Networking
+
+`src/lib/rateLimiter` queues requests per host and retries failed attempts up to three times. When the server signals rate limiting the job waits according to the reset timer. This ensures both APIs are used politely and shields the CLI from temporary failures.
+
+## Update Check
+
+On startup the CLI queries GitHub Releases (`https://api.github.com/repos/meza/minecraft-mod-manager/releases`) using the rate‑limited fetch helper. If a newer semver tag exists the user is informed about the available update after the command completes.
+

--- a/docs/requirements-go-port.md
+++ b/docs/requirements-go-port.md
@@ -1,0 +1,44 @@
+# Requirements for Go Port
+
+This document summarizes the features of the current TypeScript implementation and lists expectations for the upcoming Go port.
+
+## Current Features
+
+The CLI offers the following commands:
+
+- `init` – interactively creates `modlist.json` with loader, game version, release types and mods folder settings.
+- `add` – fetches a mod from CurseForge or Modrinth, downloads it and updates both configuration files. Supports version pinning and version fallback.
+- `install` – ensures every mod listed in `modlist.json` is downloaded according to `modlist-lock.json`, reusing hashed versions when present.
+- `update` – checks for new releases of configured mods and updates both the local files and lock file.
+- `list` – prints the configured mods and whether they are currently installed.
+- `change` – verifies if a different Minecraft version is supported, rewrites configuration and reinstalls mods.
+- `test` – tests if a target game version is viable without altering the configuration. Exit codes signal success or failure.
+- `prune` – removes unmanaged files in the mods folder. Honours `.mmmignore` patterns and supports a force option.
+- `scan` – searches the mods directory for manually added files, matches them against the supported platforms and optionally updates the config.
+- `remove` – deletes one or more mods from the config and filesystem. Supports glob patterns and a dry‑run mode.
+
+Detailed information about what each command does and how it behaves is captured in
+[the command reference](commands/README.md).
+
+Configuration lives in `modlist.json` and `modlist-lock.json`. The lock file is entirely managed by the tool and should be committed alongside the main config. Ignored files can be listed in `.mmmignore`.
+
+Global CLI flags include `--config` for selecting an alternative config file, `--quiet` to suppress prompts and regular logging, and `--debug` for verbose output. The Node version loads environment variables via `dotenv`, allowing values to be stored in a local `.env` file.
+
+Environment variables include `CURSEFORGE_API_KEY`, `MODRINTH_API_KEY`, `POSTHOG_API_KEY` and `HELP_URL`. Defaults are provided in `src/env.ts`.
+
+## Telemetry and Networking
+
+Telemetry events are sent through PostHog (`src/telemetry/telemetry.ts`). Network requests such as GitHub release checks and Minecraft version verification run through a custom rate‑limited fetch utility (`src/lib/rateLimiter`).
+
+## Platform APIs
+
+The repositories handling CurseForge and Modrinth requests are explained in [platform-apis.md](platform-apis.md). These notes cover authentication, endpoints and the fallback behaviour used when versions are missing.
+
+## Quality Guarantees
+
+The project enforces 100% unit test coverage via Vitest (`vitest.config.ts`). An ADR defines that `console.log` and `console.error` must only be used from the `actions` folder (`doc/adr/0002-console-log-only-in-actions.md`).
+
+## Bubbletea/Charm TUI Expectations
+
+The Go port will rely on the Bubbletea ecosystem for interactive consoles. Implementations should follow Charm’s recommended patterns: models must be testable, pure functions should return commands, and views should avoid side effects. Error messages and user prompts must match the current CLI behaviour.
+


### PR DESCRIPTION
## Summary
- document the repository mechanics for CurseForge and Modrinth
- link the new platform API reference from the requirements overview
- update agent guidance with a pointer to the API notes
- explain global CLI flags and GitHub update check

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685580a6ced0832f9ade7e41e6941051