### PR TITLE
Add TUI skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ You currently can
 - [automatically update mods](#update)
 - [change minecraft versions and uppdate the mods](#change)
 - [automatically recognize manually added files](#scan)
+### Terminal UI
+
+Running `mmm` without a subcommand opens an interactive terminal interface. Use the arrow keys to navigate and `q` to quit.
+
 
 Upcoming features:
 

--- a/cmd/mmm/root.go
+++ b/cmd/mmm/root.go
@@ -2,11 +2,13 @@ package mmm
 
 import (
 	"fmt"
+	tea "github.com/charmbracelet/bubbletea"
 	initCmd "github.com/meza/minecraft-mod-manager/cmd/mmm/init"
 	"github.com/meza/minecraft-mod-manager/cmd/mmm/version"
 	"github.com/meza/minecraft-mod-manager/internal/constants"
 	"github.com/meza/minecraft-mod-manager/internal/environment"
 	"github.com/meza/minecraft-mod-manager/internal/i18n"
+	"github.com/meza/minecraft-mod-manager/internal/tui"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 	"os"
@@ -18,6 +20,11 @@ func Command() *cobra.Command {
 		Use:     constants.COMMAND_NAME,
 		Short:   i18n.T("app.description"),
 		Version: environment.AppVersion(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			program := tea.NewProgram(tui.NewAppModel())
+			_, err := program.Run()
+			return err
+		},
 	}
 
 	rootCmd.SetVersionTemplate("{{.Version}}\n")

--- a/docs/tui-plan.md
+++ b/docs/tui-plan.md
@@ -1,0 +1,31 @@
+# TUI Design Plan
+
+This document outlines the planned structure for the Bubbletea based interface.
+
+## Goals
+- Provide a fullscreen terminal UI for managing all commands.
+- Display a header with the application name and version.
+- Navigate using the keyboard with clear key hints.
+- Mirror the behaviour of the existing CLI commands.
+
+## Layout
+1. **Header** – shows "Minecraft Mod Manager" and the current version.
+2. **Main Menu** – list of operations:
+   - init
+   - add
+   - install
+   - update
+   - list
+   - change
+   - test
+   - prune
+   - scan
+   - remove
+3. **Footer** – help text for key bindings (`↑/↓` to move, `enter` to select, `q` to quit).
+
+Each menu entry opens a dedicated Bubbletea model that implements the logic described in the docs under `docs/commands/`.
+
+## Implementation Notes
+- Models must remain testable and free from side effects.
+- Views should rely on the styling helpers under `internal/tui`.
+- The `main` command starts the TUI when run without sub‑commands.

--- a/internal/i18n/lang/de.json
+++ b/internal/i18n/lang/de.json
@@ -136,5 +136,8 @@
   },
   "key.up": {
     "other": "Aufwärts"
+  },
+  "tui.header": {
+    "other": "Minecraft Mod Manager"
   }
 }

--- a/internal/i18n/lang/en-GB.json
+++ b/internal/i18n/lang/en-GB.json
@@ -136,5 +136,8 @@
   },
   "key.up": {
     "other": "up"
+  },
+  "tui.header": {
+    "other": "Minecraft Mod Manager"
   }
 }

--- a/internal/i18n/lang/fr-CA.json
+++ b/internal/i18n/lang/fr-CA.json
@@ -1,1 +1,5 @@
-{}
+{
+  "tui.header": {
+    "other": "Minecraft Mod Manager"
+  }
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,0 +1,61 @@
+package tui
+
+import (
+	"fmt"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type MenuItem string
+
+func (m MenuItem) FilterValue() string { return string(m) }
+
+// AppModel is the root TUI model.
+type AppModel struct {
+	list list.Model
+}
+
+func NewAppModel() AppModel {
+	items := []list.Item{
+		MenuItem("init"),
+		MenuItem("add"),
+		MenuItem("install"),
+		MenuItem("update"),
+		MenuItem("list"),
+		MenuItem("change"),
+		MenuItem("test"),
+		MenuItem("prune"),
+		MenuItem("scan"),
+		MenuItem("remove"),
+	}
+
+	l := list.New(items, list.NewDefaultDelegate(), 0, 0)
+	l.Title = "Minecraft Mod Manager"
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(false)
+
+	return AppModel{list: l}
+}
+
+func (m AppModel) Init() tea.Cmd { return nil }
+
+func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "q" || msg.String() == "esc" || msg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
+	case tea.WindowSizeMsg:
+		m.list.SetSize(msg.Width, msg.Height-1)
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m AppModel) View() string {
+	header := lipgloss.NewStyle().Bold(true).Render(m.list.Title)
+	return fmt.Sprintf("%s\n%s", header, m.list.View())
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,0 +1,54 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestAppModel_ViewContainsHeader(t *testing.T) {
+	t.Setenv("MMM_TEST", "true")
+	m := NewAppModel()
+	view := m.View()
+	if !strings.Contains(view, "Minecraft Mod Manager") {
+		t.Errorf("view missing header: %s", view)
+	}
+}
+
+func TestMenuItem_FilterValue(t *testing.T) {
+	var m MenuItem = "init"
+	if m.FilterValue() != "init" {
+		t.Errorf("unexpected value %s", m.FilterValue())
+	}
+}
+
+func TestAppModel_Init(t *testing.T) {
+	t.Setenv("MMM_TEST", "true")
+	m := NewAppModel()
+	if m.Init() != nil {
+		t.Error("init should return nil")
+	}
+}
+
+func TestAppModel_UpdateQuit(t *testing.T) {
+	t.Setenv("MMM_TEST", "true")
+	m := NewAppModel()
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd == nil {
+		t.Fatal("expected quit command")
+	}
+}
+
+func TestAppModel_UpdateWindowSize(t *testing.T) {
+	t.Setenv("MMM_TEST", "true")
+	m := NewAppModel()
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 25})
+	um, ok := updated.(AppModel)
+	if !ok {
+		t.Fatalf("expected AppModel")
+	}
+	if um.list.Width() != 80 {
+		t.Errorf("expected width 80 got %d", um.list.Width())
+	}
+}


### PR DESCRIPTION
## Summary
- create basic fullscreen TUI model
- make main command launch the TUI when no subcommand is given
- document design in `docs/tui-plan.md`
- update README with short TUI instructions
- add tests for the new model

## Testing
- `make test` *(fails: TestRLHTTPClient_Fetch due to network)*
- `make coverage-enforce` *(fails: TestRLHTTPClient_Fetch due to network)*
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_6855a44ab724832f90f63a26c4a0ee57