### PR TITLE
Add modular TUI skeleton

### DIFF
--- a/cmd/mmm/init/init.go
+++ b/cmd/mmm/init/init.go
@@ -2,9 +2,9 @@ package init
 
 import (
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/meza/minecraft-mod-manager/internal/i18n"
 	"github.com/meza/minecraft-mod-manager/internal/models"
+	"github.com/meza/minecraft-mod-manager/internal/tui"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -37,7 +37,7 @@ func runTUI(cmd *cobra.Command, _ []string) {
 		cmd.Flag("mods-folder").Value.String(),
 	)
 
-	_, err := tea.NewProgram(model).Run()
+	err := tui.RunApp([]tui.Component{{Name: "Init", Model: model}})
 	if err != nil {
 		fmt.Println("Error running program:", err)
 		os.Exit(1)

--- a/internal/tui/__snapshots__/app_test.snap
+++ b/internal/tui/__snapshots__/app_test.snap
@@ -1,0 +1,31 @@
+
+[TestNewAppModel - 1]
+──────────────────                       
+                    content              
+  List                                   
+  ❯ Init                                 
+                                         
+                                         
+    ↑/k                                  
+  key.help.up •                          
+  ↓/j                                    
+  key.help.down                          
+  • /                                    
+  key.help.filte                         
+  r • key.esc                            
+  key.help.clear                         
+  _filter •                              
+  key.enter                              
+  key.help.apply                         
+  _filter •                              
+  key.esc                                
+  key.help.cance                         
+  l • q                                  
+  key.help.quit                          
+  • ?                                    
+  key.help.more                          
+                                         
+                                         
+──────────────────                       
+↑/↓ Navigate • ↵ Select • Q Quit • H Help
+---

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,0 +1,111 @@
+package tui
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const sidebarWidth = 18
+
+type Component struct {
+	Name  string
+	Model tea.Model
+}
+
+type AppModel struct {
+	width, height int
+	sidebar       list.Model
+	content       tea.Model
+	components    []Component
+}
+
+func NewAppModel(components []Component) *AppModel {
+	items := make([]list.Item, len(components))
+	for i, c := range components {
+		items[i] = menuItem(c.Name)
+	}
+
+	l := list.New(items, menuDelegate{}, sidebarWidth, 0)
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(false)
+	l.Styles.Title = TitleStyle
+	l.Styles.TitleBar = TitleStyle
+	l.Styles.HelpStyle = HelpStyle
+	l.Styles.PaginationStyle = PaginationStyle
+	l.KeyMap = TranslatedListKeyMap()
+
+	return &AppModel{
+		sidebar:    l,
+		content:    components[0].Model,
+		components: components,
+	}
+}
+
+func (m AppModel) Init() tea.Cmd { return nil }
+
+func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.sidebar.SetHeight(msg.Height - 1)
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			if idx := m.sidebar.Index(); idx >= 0 && idx < len(m.components) {
+				m.content = m.components[idx].Model
+			}
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		}
+	}
+
+	var cmd tea.Cmd
+	m.sidebar, cmd = m.sidebar.Update(msg)
+	cmds = append(cmds, cmd)
+	if m.content != nil {
+		m.content, cmd = m.content.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m AppModel) View() string {
+	sidebar := SidebarStyle.Render(m.sidebar.View())
+	main := MainStyle.Width(m.width - sidebarWidth - 2).Height(m.height - 1).Render(m.content.View())
+	body := lipgloss.JoinHorizontal(lipgloss.Top, sidebar, main)
+	footer := FooterStyle.Width(m.width).Render("↑/↓ Navigate • ↵ Select • Q Quit • H Help")
+	return lipgloss.JoinVertical(lipgloss.Left, body, footer)
+}
+
+type menuItem string
+
+func (i menuItem) FilterValue() string { return string(i) }
+
+type menuDelegate struct{}
+
+func (d menuDelegate) Height() int                             { return 1 }
+func (d menuDelegate) Spacing() int                            { return 0 }
+func (d menuDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+func (d menuDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	item, ok := listItem.(menuItem)
+	if !ok {
+		return
+	}
+	label := string(item)
+	if index == m.Index() {
+		fmt.Fprint(w, SelectedItemStyle.Render("❯ "+label))
+	} else {
+		fmt.Fprint(w, ItemStyle.Render(label))
+	}
+}
+
+func RunApp(components []Component) error {
+	_, err := tea.NewProgram(NewAppModel(components)).Run()
+	return err
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,0 +1,20 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gkampitakis/go-snaps/snaps"
+)
+
+type dummyModel struct{}
+
+func (d dummyModel) Init() tea.Cmd                           { return nil }
+func (d dummyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { return d, nil }
+func (d dummyModel) View() string                            { return "content" }
+
+func TestNewAppModel(t *testing.T) {
+	t.Setenv("MMM_TEST", "true")
+	m := NewAppModel([]Component{{Name: "Init", Model: dummyModel{}}})
+	snaps.MatchSnapshot(t, m.View())
+}

--- a/internal/tui/styling.go
+++ b/internal/tui/styling.go
@@ -15,4 +15,18 @@ var (
 	HelpStyle         = list.DefaultStyles().HelpStyle.PaddingLeft(2).PaddingBottom(1)
 	PlaceholderStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#767676")).PaddingLeft(1)
 	ErrorStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("#ff0000")).Bold(true)
+
+	SidebarStyle = lipgloss.NewStyle().
+			Padding(1, 2).
+			Width(18).
+			Border(lipgloss.NormalBorder(), true, false, true, false).
+			BorderForeground(lipgloss.Color("240")).
+			Background(lipgloss.Color("235"))
+
+	MainStyle = lipgloss.NewStyle().
+			Padding(1, 2)
+
+	FooterStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("250")).
+			Background(lipgloss.Color("236"))
 )


### PR DESCRIPTION
## Summary
- design a central `AppModel` with sidebar, content panel and footer
- allow registering TUI components
- wire `init` command into the new skeleton
- add styling helpers and tests

## Testing
- `make build`
- `make test` *(fails: Do_with_HTTP_client_error)*
- `make coverage-enforce` *(fails: Do_with_HTTP_client_error)*

------
https://chatgpt.com/codex/tasks/task_e_6855b0e59e78832f8edd8a5925dacc75