### PR TITLE
Move init TUI model under internal package

### DIFF
--- a/cmd/mmm/init/init.go
+++ b/cmd/mmm/init/init.go
@@ -5,6 +5,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/meza/minecraft-mod-manager/internal/i18n"
 	"github.com/meza/minecraft-mod-manager/internal/models"
+	"github.com/meza/minecraft-mod-manager/internal/tui"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -30,7 +31,7 @@ func Command() *cobra.Command {
 }
 
 func runTUI(cmd *cobra.Command, _ []string) {
-	model := NewModel(
+	model := tui.NewInitModel(
 		cmd.Flag("loader").Value.String(),
 		cmd.Flag("game-version").Value.String(),
 		cmd.Flag("release-types").Value.String(),

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -61,8 +61,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.String() == "q" || msg.String() == "Q" {
 				return m, tea.Quit
 			}
-		default:
-			panic("unhandled default case")
 		}
 
 	case tea.WindowSizeMsg:
@@ -73,7 +71,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) modlistStatusText() string {
-	//return "shit"
 	if m.modlistPresent {
 		return "Yes"
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,0 +1,52 @@
+package tui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"testing"
+)
+
+func TestModlistStatusText(t *testing.T) {
+	m := model{modlistPresent: true}
+	if m.modlistStatusText() != "Yes" {
+		t.Errorf("expected Yes")
+	}
+	m.modlistPresent = false
+	if m.modlistStatusText() != "No" {
+		t.Errorf("expected No")
+	}
+}
+
+func TestUpdateUnknownKeyDoesNotPanic(t *testing.T) {
+	m := model{}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Update panicked: %v", r)
+		}
+	}()
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	_, _ = m.Update(modlistStatusMsg(true))
+}
+
+func TestCmdHelpers(t *testing.T) {
+	cwd := cwdCmd()
+	_ = cwd()
+	tick := tickCmd(0)
+	_ = tick()
+}
+
+func TestInitAndView(t *testing.T) {
+	m := model{}
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatalf("expected command")
+	}
+	m.width = 10
+	m.height = 5
+	_ = m.View()
+}
+
+func TestRunApp(t *testing.T) {
+	if RunApp() == nil {
+		t.Fatalf("expected program")
+	}
+}

--- a/internal/tui/header_test.go
+++ b/internal/tui/header_test.go
@@ -1,0 +1,40 @@
+package tui
+
+import "testing"
+
+func TestHeaderHelpers(t *testing.T) {
+	g := makeGradient(5)
+	if len(g) != 5 {
+		t.Fatalf("expected gradient length 5, got %d", len(g))
+	}
+	if max(1, 2) != 2 || max(3, 1) != 3 {
+		t.Fatalf("max not correct")
+	}
+	r, g2, b := hexToRGB("#ffffff")
+	if r == 0 && g2 == 0 && b == 0 {
+		t.Fatalf("hexToRGB failed")
+	}
+	hexToRGB("#abc")
+	_ = isLight("#ffffff")
+}
+
+func TestRenderFloating(t *testing.T) {
+	h := RenderFloating(Config{App: "A", Version: "1"}, 10)
+	if len(h) == 0 {
+		t.Fatalf("expected header string")
+	}
+}
+
+func TestHeader(t *testing.T) {
+	h := Header(Config{App: "A", Version: "1"}, 10)
+	if len(h) == 0 {
+		t.Fatalf("expected header")
+	}
+}
+
+func TestRenderPills(t *testing.T) {
+	p := RenderPills(Config{App: "A", Version: "1"}, 10)
+	if len(p) == 0 {
+		t.Fatalf("expected pills string")
+	}
+}

--- a/internal/tui/init.go
+++ b/internal/tui/init.go
@@ -1,4 +1,4 @@
-package init
+package tui
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
@@ -13,17 +13,17 @@ const (
 	done
 )
 
-type CommandModel struct {
+type InitModel struct {
 	state               state
 	loaderQuestion      LoaderModel
 	gameVersionQuestion GameVersionModel
 }
 
-func (m CommandModel) Init() tea.Cmd {
+func (m InitModel) Init() tea.Cmd {
 	return nil
 }
 
-func (m CommandModel) View() string {
+func (m InitModel) View() string {
 	stringBuilder := strings.Builder{}
 	stringBuilder.WriteString(m.loaderQuestion.View())
 
@@ -44,7 +44,7 @@ func (m CommandModel) View() string {
 
 }
 
-func (m CommandModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m InitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
 	var cmd tea.Cmd
@@ -74,8 +74,8 @@ func (m CommandModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
-func NewModel(loader string, gameVersion string, releaseTypes string, modsFolder string) *CommandModel {
-	model := &CommandModel{
+func NewInitModel(loader string, gameVersion string, releaseTypes string, modsFolder string) *InitModel {
+	model := &InitModel{
 		loaderQuestion:      NewLoaderModel(loader),
 		gameVersionQuestion: NewGameVersionModel(gameVersion),
 		//selectedReleaseTypes: parseReleaseTypes(releaseTypes),

--- a/internal/tui/init_gameVersion.go
+++ b/internal/tui/init_gameVersion.go
@@ -1,4 +1,4 @@
-package init
+package tui
 
 import (
 	"fmt"
@@ -7,7 +7,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/meza/minecraft-mod-manager/internal/i18n"
 	"github.com/meza/minecraft-mod-manager/internal/minecraft"
-	"github.com/meza/minecraft-mod-manager/internal/tui"
 	"net/http"
 )
 
@@ -19,7 +18,7 @@ type GameVersionModel struct {
 	tea.Model
 	input  textinput.Model
 	help   help.Model
-	keymap tui.TranslatedInputKeyMap
+	keymap TranslatedInputKeyMap
 	error  error
 	Value  string
 }
@@ -72,13 +71,13 @@ func (m GameVersionModel) Update(msg tea.Msg) (GameVersionModel, tea.Cmd) {
 
 func (m GameVersionModel) View() string {
 	if m.Value != "" {
-		return fmt.Sprintf("%s%s", m.input.Prompt, tui.SelectedItemStyle.Render(m.Value))
+		return fmt.Sprintf("%s%s", m.input.Prompt, SelectedItemStyle.Render(m.Value))
 	}
 
 	errorString := ""
 
 	if m.error != nil {
-		errorString = tui.ErrorStyle.Render(" <- " + m.error.Error())
+		errorString = ErrorStyle.Render(" <- " + m.error.Error())
 	}
 
 	return fmt.Sprintf("%s%s\n\n%s", m.input.View(), errorString, m.help.View(m.keymap))
@@ -97,9 +96,9 @@ func NewGameVersionModel(gameVersion string) GameVersionModel {
 	allVersions := minecraft.GetAllMineCraftVersions(http.DefaultClient)
 
 	m := textinput.New()
-	m.Prompt = tui.QuestionStyle.Render("? ") + tui.TitleStyle.Render(i18n.T("cmd.init.tui.game-version.question")) + " "
+	m.Prompt = QuestionStyle.Render("? ") + TitleStyle.Render(i18n.T("cmd.init.tui.game-version.question")) + " "
 	m.Placeholder = latestVersion
-	m.PlaceholderStyle = tui.PlaceholderStyle
+	m.PlaceholderStyle = PlaceholderStyle
 	m.ShowSuggestions = true
 	m.SetSuggestions(allVersions)
 	m.Focus()
@@ -107,7 +106,7 @@ func NewGameVersionModel(gameVersion string) GameVersionModel {
 	model := GameVersionModel{
 		input:  m,
 		help:   help.New(),
-		keymap: tui.TranslatedInputKeyMap{},
+		keymap: TranslatedInputKeyMap{},
 	}
 
 	if minecraft.IsValidVersion(gameVersion, http.DefaultClient) {

--- a/internal/tui/init_loader.go
+++ b/internal/tui/init_loader.go
@@ -1,4 +1,4 @@
-package init
+package tui
 
 import (
 	"fmt"
@@ -7,7 +7,6 @@ import (
 	"github.com/charmbracelet/x/term"
 	"github.com/meza/minecraft-mod-manager/internal/i18n"
 	"github.com/meza/minecraft-mod-manager/internal/models"
-	"github.com/meza/minecraft-mod-manager/internal/tui"
 	"io"
 	"os"
 )
@@ -52,7 +51,7 @@ func (m LoaderModel) Update(msg tea.Msg) (LoaderModel, tea.Cmd) {
 func (m LoaderModel) View() string {
 
 	if m.Value != "" {
-		return fmt.Sprintf("%s %s", m.Title(), tui.SelectedItemStyle.Render(string(m.Value)))
+		return fmt.Sprintf("%s %s", m.Title(), SelectedItemStyle.Render(string(m.Value)))
 	}
 	return m.list.View()
 }
@@ -81,11 +80,11 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, itemIndex int, listItem 
 	itemLine := fmt.Sprintf("%s", item)
 
 	if itemIndex == m.Index() {
-		fmt.Fprint(w, tui.SelectedItemStyle.Render("❯ "+itemLine))
+		fmt.Fprint(w, SelectedItemStyle.Render("❯ "+itemLine))
 		return
 	}
 
-	fmt.Fprint(w, tui.ItemStyle.Render(itemLine))
+	fmt.Fprint(w, ItemStyle.Render(itemLine))
 }
 
 type loaderType string
@@ -103,14 +102,14 @@ func NewLoaderModel(loader string) LoaderModel {
 	}
 
 	listModel := list.New(items, itemDelegate{}, width, 14)
-	listModel.Title = tui.QuestionStyle.Render("? ") + tui.TitleStyle.Render(i18n.T("cmd.init.tui.loader.question"))
+	listModel.Title = QuestionStyle.Render("? ") + TitleStyle.Render(i18n.T("cmd.init.tui.loader.question"))
 	listModel.SetShowStatusBar(false)
 	listModel.SetShowTitle(true)
-	listModel.Styles.Title = tui.TitleStyle
-	listModel.Styles.TitleBar = tui.TitleStyle
-	listModel.Styles.PaginationStyle = tui.PaginationStyle
-	listModel.Styles.HelpStyle = tui.HelpStyle
-	listModel.KeyMap = tui.TranslatedListKeyMap()
+	listModel.Styles.Title = TitleStyle
+	listModel.Styles.TitleBar = TitleStyle
+	listModel.Styles.PaginationStyle = PaginationStyle
+	listModel.Styles.HelpStyle = HelpStyle
+	listModel.KeyMap = TranslatedListKeyMap()
 
 	model := LoaderModel{
 		list: listModel,

--- a/internal/tui/init_test.go
+++ b/internal/tui/init_test.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"testing"
+)
+
+func TestInitModelStateTransitions(t *testing.T) {
+	m := NewInitModel("", "", "", "")
+	_ = m.Init()
+	if m.state != stateLoader {
+		t.Fatalf("expected loader state")
+	}
+	m2, _ := m.Update(LoaderSelectedMessage{})
+	im := m2.(InitModel)
+	if im.state != stateGameVersion {
+		t.Fatalf("expected game version state")
+	}
+	m3, cmd := im.Update(GameVersionSelectedMessage{})
+	im = m3.(InitModel)
+	if im.state != done {
+		t.Fatalf("expected done state")
+	}
+	if cmd == nil {
+		t.Fatalf("expected quit command")
+	}
+	_ = im.View()
+}
+
+func TestLoaderModelRender(t *testing.T) {
+	lm := NewLoaderModel("")
+	_ = lm.View()
+	_ = lm.Title()
+	lm, _ = lm.Update(tea.WindowSizeMsg{Width: 10})
+	lm, _ = lm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if msg := lm.loaderSelected()(); msg == nil {
+		t.Fatalf("expected loader selected message")
+	}
+}
+
+func TestGameVersionModelRender(t *testing.T) {
+	gm := GameVersionModel{}
+	_ = gm.Init()
+	_ = gm.View()
+	_, _ = gm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	_ = gm.gameVersionSelected()()
+	_ = isValidMinecraftVersion("")
+	_ = isValidMinecraftVersion("1.0")
+}


### PR DESCRIPTION
## Summary
- relocate init TUI code from command folder to `internal/tui`
- expose `NewInitModel` for the init command
- clean up panic and comment in TUI app model
- add initial tests for TUI components

## Testing
- `make test`
- `make build`
- `make coverage-enforce` *(fails: Coverage is not 100%)*

------
https://chatgpt.com/codex/tasks/task_e_6857095ef314832f85bab7283fc7d59b