### PR TITLE
feat: add modular init wizard

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -8,6 +8,9 @@ import (
 	"time"
 )
 
+var getwd = os.Getwd
+var absPath = filepath.Abs
+
 type modlistStatusMsg bool
 type cwdMsg string
 
@@ -15,15 +18,22 @@ type model struct {
 	width, height  int
 	modlistPresent bool
 	cwd            string
+	content        helpModel
+}
+
+type helpModel interface {
+	tea.Model
+	Help() string
+	SetSize(width, height int)
 }
 
 func cwdCmd() tea.Cmd {
 	return func() tea.Msg {
-		wd, err := os.Getwd()
+		wd, err := getwd()
 		if err != nil {
 			return cwdMsg("unknown")
 		}
-		abs, err := filepath.Abs(wd)
+		abs, err := absPath(wd)
 		if err != nil {
 			return cwdMsg(wd)
 		}
@@ -39,10 +49,14 @@ func tickCmd(d time.Duration) tea.Cmd {
 }
 
 func (m model) Init() tea.Cmd {
-	return tea.Batch(
-		tickCmd(5*time.Second),
+	cmds := []tea.Cmd{
+		tickCmd(5 * time.Second),
 		cwdCmd(),
-	)
+	}
+	if m.content != nil {
+		cmds = append(cmds, m.content.Init())
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -66,6 +80,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		if m.content != nil {
+			m.content.SetSize(m.width, m.height)
+		}
+	}
+	if m.content != nil {
+		var cCmd tea.Cmd
+		var newModel tea.Model
+		newModel, cCmd = m.content.Update(msg)
+		m.content = newModel.(helpModel)
+		return m, cCmd
 	}
 	return m, nil
 }
@@ -100,14 +124,37 @@ func (m model) View() string {
 		PaddingTop(0).
 		Render("Sidebar")
 
+	contentWidth := m.width - lipgloss.Width(sidebar)
+	if m.content != nil {
+		m.content.SetSize(contentWidth, m.height-lipgloss.Height(header)-lipgloss.Height(footer))
+	}
+
+	var contentView string
+	if m.content != nil {
+		if v, ok := m.content.(tea.Model); ok {
+			contentView = v.View()
+		}
+	} else {
+		contentView = "content"
+	}
+
 	content := lipgloss.NewStyle().
-		Width(m.width-lipgloss.Width(sidebar)).
+		Width(contentWidth).
 		Height(m.height-lipgloss.Height(header)-lipgloss.Height(footer)).
 		Align(lipgloss.Left, lipgloss.Top).
 		PaddingTop(0).
-		Render("content")
+		Render(contentView)
 
 	main := lipgloss.JoinHorizontal(lipgloss.Top, sidebar, content)
+
+	helpText := ""
+	if m.content != nil {
+		helpText = m.content.Help()
+	}
+	footer = lipgloss.NewStyle().
+		Align(lipgloss.Left).
+		Width(m.width).
+		Render(helpText)
 
 	return lipgloss.JoinVertical(lipgloss.Top, header, main, footer)
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,9 +1,19 @@
 package tui
 
 import (
+	"os"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"testing"
 )
+
+type stubModel struct{}
+
+func (s stubModel) Init() tea.Cmd                           { return nil }
+func (s stubModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { return s, nil }
+func (s stubModel) View() string                            { return "stub" }
+func (s stubModel) Help() string                            { return "help" }
+func (s stubModel) SetSize(width, height int)               {}
 
 func TestModlistStatusText(t *testing.T) {
 	m := model{modlistPresent: true}
@@ -27,21 +37,58 @@ func TestUpdateUnknownKeyDoesNotPanic(t *testing.T) {
 	_, _ = m.Update(modlistStatusMsg(true))
 }
 
+func TestModelUpdateWithoutContent(t *testing.T) {
+	m := model{}
+	_, _ = m.Update(modlistStatusMsg(false))
+	_, _ = m.Update(cwdMsg("here"))
+	_, _ = m.Update(tea.WindowSizeMsg{Width: 1, Height: 1})
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	_ = m.View()
+}
+
 func TestCmdHelpers(t *testing.T) {
+	oldGetwd := getwd
+	oldAbs := absPath
+	getwd = func() (string, error) { return "", os.ErrNotExist }
+	absPath = func(p string) (string, error) { return "", os.ErrNotExist }
 	cwd := cwdCmd()
 	_ = cwd()
+	getwd = func() (string, error) { return "/tmp", nil }
+	absPath = func(p string) (string, error) { return "/abs", nil }
+	_ = cwdCmd()()
+	getwd = oldGetwd
+	absPath = oldAbs
 	tick := tickCmd(0)
 	_ = tick()
 }
 
 func TestInitAndView(t *testing.T) {
-	m := model{}
+	m := model{content: stubModel{}}
 	cmd := m.Init()
 	if cmd == nil {
 		t.Fatalf("expected command")
 	}
 	m.width = 10
 	m.height = 5
+	_ = m.View()
+	nm, _ := m.Update(tea.WindowSizeMsg{Width: 20, Height: 10})
+	m = nm.(model)
+	if m.width != 20 {
+		t.Fatalf("width not set")
+	}
+	_ = m.View()
+}
+
+func TestModelUpdateWithContent(t *testing.T) {
+	m := model{content: stubModel{}}
+	m.width = 5
+	m.height = 5
+	_, _ = m.Update(modlistStatusMsg(true))
+	_, _ = m.Update(cwdMsg("/tmp"))
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	_, _ = m.Update(tea.WindowSizeMsg{Width: 5, Height: 5})
 	_ = m.View()
 }
 

--- a/internal/tui/init_gameVersion.go
+++ b/internal/tui/init_gameVersion.go
@@ -23,6 +23,8 @@ type GameVersionModel struct {
 	Value  string
 }
 
+var validVersionFn = minecraft.IsValidVersion
+
 func (m GameVersionModel) Init() tea.Cmd {
 	return nil
 }
@@ -121,8 +123,15 @@ func isValidMinecraftVersion(value string) error {
 		return fmt.Errorf(i18n.T("cmd.init.tui.game-version.error"))
 	}
 
-	if !minecraft.IsValidVersion(value, http.DefaultClient) {
+	if !validVersionFn(value, http.DefaultClient) {
 		return fmt.Errorf(i18n.T("cmd.init.tui.game-version.invalid"))
 	}
 	return nil
+}
+
+func (m GameVersionModel) Help() string { return m.help.View(m.keymap) }
+
+func (m GameVersionModel) SetSize(width, _ int) GameVersionModel {
+	m.input.Width = width
+	return m
 }

--- a/internal/tui/init_loader.go
+++ b/internal/tui/init_loader.go
@@ -21,6 +21,8 @@ type LoaderModel struct {
 	Value models.Loader
 }
 
+var termSizeFn = term.GetSize
+
 func (m LoaderModel) Init() tea.Cmd {
 	return nil
 }
@@ -66,6 +68,13 @@ func (m LoaderModel) loaderSelected() tea.Cmd {
 	}
 }
 
+func (m LoaderModel) Help() string { return m.list.Help.View(m.list) }
+
+func (m LoaderModel) SetSize(width, _ int) LoaderModel {
+	m.list.SetWidth(width)
+	return m
+}
+
 type itemDelegate struct{}
 
 func (d itemDelegate) Height() int                             { return 1 }
@@ -92,7 +101,7 @@ type loaderType string
 func (i loaderType) FilterValue() string { return "" }
 
 func NewLoaderModel(loader string) LoaderModel {
-	width, _, _ := term.GetSize(os.Stdout.Fd())
+	width, _, _ := termSizeFn(os.Stdout.Fd())
 
 	loaderOptions := models.AllLoaders()
 	items := make([]list.Item, 0)

--- a/internal/tui/init_modsfolder.go
+++ b/internal/tui/init_modsfolder.go
@@ -1,0 +1,72 @@
+package tui
+
+import (
+	"fmt"
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/meza/minecraft-mod-manager/internal/i18n"
+)
+
+type ModsFolderSelectedMessage struct{ ModsFolder string }
+
+type ModsFolderModel struct {
+	input  textinput.Model
+	help   help.Model
+	keymap TranslatedInputKeyMap
+	Value  string
+}
+
+func NewModsFolderModel(folder string) ModsFolderModel {
+	m := textinput.New()
+	m.Prompt = QuestionStyle.Render("? ") + TitleStyle.Render(i18n.T("cmd.init.tui.mods-folder.question")) + " "
+	m.Placeholder = "mods"
+	m.PlaceholderStyle = PlaceholderStyle
+	m.Focus()
+	model := ModsFolderModel{input: m, help: help.New(), keymap: TranslatedInputKeyMap{}}
+	if folder != "" {
+		model.Value = folder
+	}
+	return model
+}
+
+func (m ModsFolderModel) Init() tea.Cmd { return nil }
+
+func (m ModsFolderModel) Update(msg tea.Msg) (ModsFolderModel, tea.Cmd) {
+	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			if m.input.Value() != "" {
+				m.Value = m.input.Value()
+				return m, m.modsFolderSelected()
+			}
+		case "tab":
+			if m.input.Value() == "" {
+				m.input.SetValue(m.input.Placeholder)
+			}
+		}
+	}
+	m.input, cmd = m.input.Update(msg)
+	return m, cmd
+}
+
+func (m ModsFolderModel) View() string {
+	if m.Value != "" {
+		return fmt.Sprintf("%s%s", m.input.Prompt, SelectedItemStyle.Render(m.Value))
+	}
+	return fmt.Sprintf("%s\n\n%s", m.input.View(), m.help.View(m.keymap))
+}
+
+func (m ModsFolderModel) modsFolderSelected() tea.Cmd {
+	m.input.Blur()
+	return func() tea.Msg { return ModsFolderSelectedMessage{ModsFolder: m.Value} }
+}
+
+func (m ModsFolderModel) Help() string { return m.help.View(m.keymap) }
+
+func (m ModsFolderModel) SetSize(width, _ int) ModsFolderModel {
+	m.input.Width = width
+	return m
+}

--- a/internal/tui/init_modsfolder_test.go
+++ b/internal/tui/init_modsfolder_test.go
@@ -1,0 +1,26 @@
+package tui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"testing"
+)
+
+func TestModsFolderModel(t *testing.T) {
+	m := NewModsFolderModel("")
+	_ = m.Init()
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.input.Value() != m.input.Placeholder {
+		t.Fatalf("expected placeholder set")
+	}
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatalf("expected command")
+	}
+	_ = m.View()
+	_ = m.modsFolderSelected()()
+	_ = m.Help()
+	m = m.SetSize(10, 0)
+	if m.input.Width != 10 {
+		t.Fatalf("expected width set")
+	}
+}

--- a/internal/tui/init_test.go
+++ b/internal/tui/init_test.go
@@ -1,23 +1,34 @@
 package tui
 
 import (
+	"bytes"
+
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/meza/minecraft-mod-manager/internal/httpClient"
+	"github.com/meza/minecraft-mod-manager/internal/minecraft"
+	"github.com/meza/minecraft-mod-manager/internal/models"
 	"testing"
 )
 
 func TestInitModelStateTransitions(t *testing.T) {
 	m := NewInitModel("", "", "", "")
 	_ = m.Init()
-	if m.state != stateLoader {
+	if m.state != stateModsFolder {
+		t.Fatalf("expected mods folder state")
+	}
+	m.SetSize(10, 10)
+	m2, _ := m.Update(ModsFolderSelectedMessage{})
+	im := m2.(InitModel)
+	if im.state != stateLoader {
 		t.Fatalf("expected loader state")
 	}
-	m2, _ := m.Update(LoaderSelectedMessage{})
-	im := m2.(InitModel)
+	m3, _ := im.Update(LoaderSelectedMessage{})
+	im = m3.(InitModel)
 	if im.state != stateGameVersion {
 		t.Fatalf("expected game version state")
 	}
-	m3, cmd := im.Update(GameVersionSelectedMessage{})
-	im = m3.(InitModel)
+	m4, cmd := im.Update(GameVersionSelectedMessage{})
+	im = m4.(InitModel)
 	if im.state != done {
 		t.Fatalf("expected done state")
 	}
@@ -25,25 +36,48 @@ func TestInitModelStateTransitions(t *testing.T) {
 		t.Fatalf("expected quit command")
 	}
 	_ = im.View()
+	_ = im.Help()
 }
 
 func TestLoaderModelRender(t *testing.T) {
 	lm := NewLoaderModel("")
 	_ = lm.View()
 	_ = lm.Title()
-	lm, _ = lm.Update(tea.WindowSizeMsg{Width: 10})
+	lm = lm.SetSize(10, 0)
 	lm, _ = lm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
-	if msg := lm.loaderSelected()(); msg == nil {
-		t.Fatalf("expected loader selected message")
+	lm, cmd := lm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatalf("expected command")
 	}
+	_ = lm.View()
+	_ = lm.Help()
+	_ = isValidLoader(models.FABRIC)
+	_ = isValidLoader(models.Loader("none"))
+	d := itemDelegate{}
+	if d.Height() != 1 || d.Spacing() != 0 {
+		t.Fatalf("delegate dims")
+	}
+	_ = d.Update(nil, nil)
+	var buf bytes.Buffer
+	d.Render(&buf, lm.list, 0, loaderType("fabric"))
+	_ = loaderType("fabric").FilterValue()
 }
 
 func TestGameVersionModelRender(t *testing.T) {
-	gm := GameVersionModel{}
+	gm := NewGameVersionModel("")
+	validVersionFn = func(string, httpClient.Doer) bool { return true }
+	defer func() { validVersionFn = minecraft.IsValidVersion }()
 	_ = gm.Init()
+	gm = gm.SetSize(10, 0)
+	gm, _ = gm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	gm, cmd := gm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatalf("expected command")
+	}
 	_ = gm.View()
-	_, _ = gm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	_ = gm.gameVersionSelected()()
 	_ = isValidMinecraftVersion("")
+	validVersionFn = func(string, httpClient.Doer) bool { return false }
 	_ = isValidMinecraftVersion("1.0")
+	_ = gm.Help()
 }


### PR DESCRIPTION
## Summary
- implement Init wizard with step models
- add contextual help and size management
- wire up help in the app footer
- expand unit tests for new models

## Testing
- `go test ./internal/...`
- `make coverage-enforce` *(fails: Coverage is not 100%: 97.0%)*

------
https://chatgpt.com/codex/tasks/task_e_685715ca3614832fbee9753b58c182b8