### PR TITLE
Implement init wizard layout

### DIFF
--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -50,3 +50,13 @@ func TestRunApp(t *testing.T) {
 		t.Fatalf("expected program")
 	}
 }
+
+func TestUpdateBranches(t *testing.T) {
+	m := model{wizard: NewInitModel("", "", "", "")}
+	_, _ = m.Update(modlistStatusMsg(true))
+	_, _ = m.Update(cwdMsg("/tmp"))
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	_, _ = m.Update(tea.WindowSizeMsg{Width: 10, Height: 5})
+	_ = m.View()
+}

--- a/internal/tui/init.go
+++ b/internal/tui/init.go
@@ -5,83 +5,143 @@ import (
 	"strings"
 )
 
-type state int
+type initStep int
 
 const (
-	stateLoader state = iota
-	stateGameVersion
-	done
+	stepFields initStep = iota
+	stepDone
 )
 
 type InitModel struct {
-	state               state
+	step                initStep
+	focus               int
+	modsFolder          ModsFolderModel
 	loaderQuestion      LoaderModel
 	gameVersionQuestion GameVersionModel
-}
-
-func (m InitModel) Init() tea.Cmd {
-	return nil
-}
-
-func (m InitModel) View() string {
-	stringBuilder := strings.Builder{}
-	stringBuilder.WriteString(m.loaderQuestion.View())
-
-	switch m.state {
-	case stateLoader:
-		return stringBuilder.String()
-	case stateGameVersion:
-		stringBuilder.WriteString("\n")
-		stringBuilder.WriteString(m.gameVersionQuestion.View())
-	case done:
-		stringBuilder.WriteString("\n")
-		stringBuilder.WriteString(m.gameVersionQuestion.View())
-	}
-
-	stringBuilder.WriteString("\n")
-	stringBuilder.WriteString("\n")
-	return stringBuilder.String()
-
-}
-
-func (m InitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var cmds []tea.Cmd
-
-	var cmd tea.Cmd
-
-	switch msg := msg.(type) {
-	case LoaderSelectedMessage:
-		m.state = stateGameVersion
-	case GameVersionSelectedMessage:
-		m.state = done
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c":
-			cmds = append(cmds, tea.Quit)
-		}
-	}
-
-	switch m.state {
-	case stateLoader:
-		m.loaderQuestion, cmd = m.loaderQuestion.Update(msg)
-	case stateGameVersion:
-		m.gameVersionQuestion, cmd = m.gameVersionQuestion.Update(msg)
-	default:
-		return m, tea.Quit
-	}
-	cmds = append(cmds, cmd)
-
-	return m, tea.Batch(cmds...)
+	width               int
 }
 
 func NewInitModel(loader string, gameVersion string, releaseTypes string, modsFolder string) *InitModel {
-	model := &InitModel{
+	m := &InitModel{
+		modsFolder:          NewModsFolderModel(modsFolder),
 		loaderQuestion:      NewLoaderModel(loader),
 		gameVersionQuestion: NewGameVersionModel(gameVersion),
-		//selectedReleaseTypes: parseReleaseTypes(releaseTypes),
-
 	}
+	m.focus = 0
+	m.focusCurrent()
+	return m
+}
 
-	return model
+func (m *InitModel) focusCurrent() {
+	switch m.focus {
+	case 0:
+		m.modsFolder.Focus()
+	case 1:
+		m.loaderQuestion.Focus()
+	case 2:
+		m.gameVersionQuestion.Focus()
+	}
+}
 
+func (m *InitModel) blurCurrent() {
+	switch m.focus {
+	case 0:
+		m.modsFolder.Blur()
+	case 1:
+		m.loaderQuestion.Blur()
+	case 2:
+		m.gameVersionQuestion.Blur()
+	}
+}
+
+func (m InitModel) Init() tea.Cmd { return nil }
+
+func (m *InitModel) nextField() {
+	m.blurCurrent()
+	m.focus = (m.focus + 1) % 3
+	m.focusCurrent()
+}
+
+func (m *InitModel) prevField() {
+	m.blurCurrent()
+	if m.focus == 0 {
+		m.focus = 2
+	} else {
+		m.focus--
+	}
+	m.focusCurrent()
+}
+
+func (m *InitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC:
+			return m, tea.Quit
+		case tea.KeyTab:
+			m.nextField()
+			return m, nil
+		case tea.KeyShiftTab:
+			m.prevField()
+			return m, nil
+		case tea.KeyRight:
+			if m.step == stepFields {
+				m.step = stepDone
+			}
+		case tea.KeyLeft:
+			if m.step == stepDone {
+				m.step = stepFields
+			}
+		case tea.KeyEnter:
+			if m.step == stepDone {
+				return m, tea.Quit
+			}
+		}
+	}
+	if m.step == stepFields {
+		switch m.focus {
+		case 0:
+			m.modsFolder, cmd = m.modsFolder.Update(msg)
+		case 1:
+			m.loaderQuestion, cmd = m.loaderQuestion.Update(msg)
+		case 2:
+			m.gameVersionQuestion, cmd = m.gameVersionQuestion.Update(msg)
+		}
+	}
+	return m, cmd
+}
+
+func (m InitModel) currentHelp() string {
+	switch m.focus {
+	case 0:
+		return m.modsFolder.HelpView()
+	case 1:
+		return m.loaderQuestion.HelpView()
+	case 2:
+		return m.gameVersionQuestion.HelpView()
+	}
+	return ""
+}
+
+func (m InitModel) View() string {
+	var b strings.Builder
+	b.WriteString(m.modsFolder.View())
+	b.WriteString("\n")
+	b.WriteString(m.loaderQuestion.View())
+	b.WriteString("\n")
+	b.WriteString(m.gameVersionQuestion.View())
+	b.WriteString("\n\n")
+	b.WriteString(m.currentHelp())
+	if m.step == stepFields {
+		b.WriteString("\n\n[Next →]")
+	} else {
+		b.WriteString("\n\n[← Back] [Finish]")
+	}
+	return b.String()
+}
+
+func (m *InitModel) SetSize(width int) {
+	m.width = width
+	m.loaderQuestion.list.SetWidth(width)
 }

--- a/internal/tui/init_loader.go
+++ b/internal/tui/init_loader.go
@@ -17,12 +17,23 @@ type LoaderSelectedMessage struct {
 
 type LoaderModel struct {
 	tea.Model
-	list  list.Model
-	Value models.Loader
+	list    list.Model
+	Value   models.Loader
+	focused bool
 }
 
 func (m LoaderModel) Init() tea.Cmd {
 	return nil
+}
+
+func (m LoaderModel) Focus() {
+	m.focused = true
+	m.list.SetShowHelp(true)
+}
+
+func (m LoaderModel) Blur() {
+	m.focused = false
+	m.list.SetShowHelp(false)
 }
 
 func (m LoaderModel) Update(msg tea.Msg) (LoaderModel, tea.Cmd) {
@@ -64,6 +75,13 @@ func (m LoaderModel) loaderSelected() tea.Cmd {
 	return func() tea.Msg {
 		return LoaderSelectedMessage{Loader: m.Value}
 	}
+}
+
+func (m LoaderModel) HelpView() string {
+	if m.focused {
+		return m.list.Help.View(m.list)
+	}
+	return ""
 }
 
 type itemDelegate struct{}

--- a/internal/tui/init_modsfolder.go
+++ b/internal/tui/init_modsfolder.go
@@ -1,0 +1,76 @@
+package tui
+
+import (
+	"fmt"
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/meza/minecraft-mod-manager/internal/i18n"
+)
+
+type ModsFolderSelectedMessage struct{ ModsFolder string }
+
+type ModsFolderModel struct {
+	input   textinput.Model
+	help    help.Model
+	keymap  TranslatedInputKeyMap
+	focused bool
+	Value   string
+	err     error
+}
+
+func (m ModsFolderModel) Init() tea.Cmd { return nil }
+
+func (m ModsFolderModel) Focus() { m.focused = true }
+func (m ModsFolderModel) Blur()  { m.focused = false }
+
+func (m ModsFolderModel) Update(msg tea.Msg) (ModsFolderModel, tea.Cmd) {
+	var cmd tea.Cmd
+	var cmds []tea.Cmd
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEnter:
+			if m.input.Value() != "" {
+				m.Value = m.input.Value()
+				m.input.Blur()
+				return m, m.modsFolderSelected()
+			}
+		}
+	}
+	m.input, cmd = m.input.Update(msg)
+	cmds = append(cmds, cmd)
+	return m, tea.Batch(cmds...)
+}
+
+func (m ModsFolderModel) modsFolderSelected() tea.Cmd {
+	return func() tea.Msg { return ModsFolderSelectedMessage{ModsFolder: m.Value} }
+}
+
+func (m ModsFolderModel) View() string {
+	if m.Value != "" {
+		return fmt.Sprintf("%s%s", m.input.Prompt, SelectedItemStyle.Render(m.Value))
+	}
+	if m.err != nil {
+		return fmt.Sprintf("%s\n%s", m.input.View(), ErrorStyle.Render(m.err.Error()))
+	}
+	if m.focused {
+		return fmt.Sprintf("%s\n\n%s", m.input.View(), m.help.View(m.keymap))
+	}
+	return m.input.View()
+}
+
+func (m ModsFolderModel) HelpView() string {
+	if m.focused {
+		return m.help.View(m.keymap)
+	}
+	return ""
+}
+
+func NewModsFolderModel(modsFolder string) ModsFolderModel {
+	ti := textinput.New()
+	ti.Prompt = QuestionStyle.Render("? ") + TitleStyle.Render(i18n.T("cmd.init.tui.mods-folder.question")) + " "
+	ti.SetValue(modsFolder)
+	ti.Focus()
+	return ModsFolderModel{input: ti, help: help.New(), keymap: TranslatedInputKeyMap{}, focused: true}
+}

--- a/internal/tui/init_test.go
+++ b/internal/tui/init_test.go
@@ -5,45 +5,107 @@ import (
 	"testing"
 )
 
-func TestInitModelStateTransitions(t *testing.T) {
+func TestInitModelNavigation(t *testing.T) {
 	m := NewInitModel("", "", "", "")
+	if m.focus != 0 {
+		t.Fatalf("expected focus 0")
+	}
 	_ = m.Init()
-	if m.state != stateLoader {
-		t.Fatalf("expected loader state")
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	im := m2.(*InitModel)
+	if im.focus != 1 {
+		t.Fatalf("tab should move focus")
 	}
-	m2, _ := m.Update(LoaderSelectedMessage{})
-	im := m2.(InitModel)
-	if im.state != stateGameVersion {
-		t.Fatalf("expected game version state")
+	m3, _ := im.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	im = m3.(*InitModel)
+	if im.focus != 0 {
+		t.Fatalf("shift tab should move focus back")
 	}
-	m3, cmd := im.Update(GameVersionSelectedMessage{})
-	im = m3.(InitModel)
-	if im.state != done {
-		t.Fatalf("expected done state")
+	m4, _ := im.Update(tea.KeyMsg{Type: tea.KeyRight})
+	im = m4.(*InitModel)
+	if im.step != stepDone {
+		t.Fatalf("right should go next")
 	}
-	if cmd == nil {
-		t.Fatalf("expected quit command")
+	m5, _ := im.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	im = m5.(*InitModel)
+	if im.step != stepFields {
+		t.Fatalf("left should go back")
 	}
+	_ = im.currentHelp()
 	_ = im.View()
+	im.SetSize(10)
+	im.focusCurrent()
+	im.blurCurrent()
+	im.nextField()
+	im.prevField()
+	_, _ = im.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+}
+
+func TestModsFolderModelRender(t *testing.T) {
+	m := NewModsFolderModel("")
+	_ = m.View()
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if msg := m.modsFolderSelected()(); msg == nil {
+		t.Fatalf("expected message")
+	}
+	_ = m.HelpView()
 }
 
 func TestLoaderModelRender(t *testing.T) {
 	lm := NewLoaderModel("")
+	lm.Focus()
 	_ = lm.View()
-	_ = lm.Title()
 	lm, _ = lm.Update(tea.WindowSizeMsg{Width: 10})
 	lm, _ = lm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	_ = lm.HelpView()
 	if msg := lm.loaderSelected()(); msg == nil {
-		t.Fatalf("expected loader selected message")
+		t.Fatalf("expected message")
 	}
 }
 
 func TestGameVersionModelRender(t *testing.T) {
-	gm := GameVersionModel{}
+	gm := NewGameVersionModel("")
+	gm.Focus()
 	_ = gm.Init()
 	_ = gm.View()
 	_, _ = gm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	_, _ = gm.Update(tea.KeyMsg{Type: tea.KeyTab})
+	gm.input.SetValue("1.20.1")
+	_, _ = gm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	_, _ = gm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	_, _ = gm.Update(tea.KeyMsg{Type: tea.KeyTab})
 	_ = gm.gameVersionSelected()()
+	_ = gm.HelpView()
 	_ = isValidMinecraftVersion("")
 	_ = isValidMinecraftVersion("1.0")
+}
+
+func TestInitModelHelpers(t *testing.T) {
+	im := NewInitModel("", "", "", "")
+	im.focus = 0
+	im.focusCurrent()
+	im.focus = 1
+	im.focusCurrent()
+	im.focus = 2
+	im.focusCurrent()
+	im.blurCurrent()
+	im.focus = 0
+	im.blurCurrent()
+	im.focus = 1
+	im.blurCurrent()
+	im.focus = 0
+	im.prevField()
+	if im.focus != 2 {
+		t.Fatalf("wrap prevField")
+	}
+	im.nextField()
+	if im.focus != 0 {
+		t.Fatalf("nextField")
+	}
+	_ = im.currentHelp()
+	im.focus = 1
+	_ = im.currentHelp()
+	im.focus = 2
+	_ = im.currentHelp()
+	_, _ = im.Update(tea.KeyMsg{Type: tea.KeyEnter})
 }


### PR DESCRIPTION
## Summary
- show wizard fields in a single view and add navigation
- keep help text in sync with focus
- size wizard in the app content area
- cover new logic with tests

## Testing
- `make test`
- `make coverage-enforce` *(fails: Coverage is not 100%)*

------
https://chatgpt.com/codex/tasks/task_e_685728fbabf0832f96331cdb784ce591