### PR TITLE
chore: enforce minimum dependency age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Enforce a seven-day minimum release age for pnpm dependencies.

## Metadata change

Created `pnpm-workspace.yaml` containing `minimumReleaseAge: 10080`.

## Verification

Inspected `git status`, the untracked-file diff, and the staged diff to confirm that only the requested metadata file was added. Package-manager commands, tests, linters, formatters, builds, and validators were intentionally not run.